### PR TITLE
feat: Migrate frontend from Bootstrap to PatternFly 6

### DIFF
--- a/internal/api/cache.go
+++ b/internal/api/cache.go
@@ -26,6 +26,26 @@ func SaveCacheToDisk(key string, data []byte) error {
 	return os.WriteFile(filepath.Join(cacheDir, keyToFilename(key)), data, 0644)
 }
 
+func RetrieveCacheLogFromDisk(key string) ([]byte, error) {
+	path := filepath.Join(cacheDir, keyToLogFilename(key))
+	if info, err := os.Stat(path); err == nil && time.Since(info.ModTime()) < 24*time.Hour {
+		return os.ReadFile(path)
+	}
+	return nil, os.ErrNotExist
+}
+
+func SaveCacheLogsToDisk(key string, data []byte) error {
+	err := os.MkdirAll(cacheDir, 0755)
+	if err != nil {
+		log.Fatalf("Failed to create directory: %v", err)
+	}
+	return os.WriteFile(filepath.Join(cacheDir, keyToLogFilename(key)), data, 0644)
+}
+
 func keyToFilename(key string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(key, "/", "_"), ":", "_") + ".json"
+}
+
+func keyToLogFilename(key string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(key, "/", "_"), ":", "_") + ".log"
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -60,6 +60,7 @@ type TaskResult struct {
 	Status TaskStatus `json:"status"`
 	Output string     `json:"output,omitempty"`
 	Error  string     `json:"error,omitempty"`
+	Logs   string     `json:"logs,omitempty"`
 }
 
 func ScanHandler(w http.ResponseWriter, r *http.Request) {
@@ -359,7 +360,10 @@ func CallgraphHandler(w http.ResponseWriter, r *http.Request) {
 
 		cacheKey := fmt.Sprintf("%s@%s:%s:lib=%s:sym=%s:fixver=%s:algo=%s", repo, branchOrCommit, cve, library, symbol, fixversion, algo)
 		if cachedData, err := RetrieveCacheFromDisk(cacheKey); err == nil {
-			updateStatus(StatusCompleted, string(cachedData), "")
+			cachedLogs, _ := RetrieveCacheLogFromDisk(cacheKey)
+			taskMutex.Lock()
+			taskStore[taskId] = &TaskResult{Status: StatusCompleted, Output: string(cachedData), Logs: string(cachedLogs)}
+			taskMutex.Unlock()
 			log.Printf("[Task %s] Retrieved callgraph from cache", taskId)
 			return
 		}
@@ -418,7 +422,7 @@ func CallgraphHandler(w http.ResponseWriter, r *http.Request) {
 		args = append(args, cve, cloneDir)
 		cmd = exec.Command("cg", args...)
 
-		output, err := runCgWithProgressCapture(cmd, sendProgress)
+		output, progressLogs, err := runCgWithProgressCapture(cmd, sendProgress)
 
 		if err != nil {
 			log.Printf("[Task %s] cg execution failed: %v", taskId, err)
@@ -434,6 +438,9 @@ func CallgraphHandler(w http.ResponseWriter, r *http.Request) {
 
 		if err := SaveCacheToDisk(cacheKey, output); err != nil {
 			log.Printf("[Task %s] Failed to save cache: %v", taskId, err)
+		}
+		if err := SaveCacheLogsToDisk(cacheKey, progressLogs); err != nil {
+			log.Printf("[Task %s] Failed to save cache logs: %v", taskId, err)
 		}
 	}(taskId, req.Repo, req.BranchOrCommit, req.CVE, req.Library, req.Symbol, req.FixVersion, req.Algo, baseURL)
 
@@ -477,6 +484,10 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	if result.Error != "" {
 		resp["error"] = result.Error
+	}
+
+	if result.Logs != "" {
+		resp["logs"] = result.Logs
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -532,26 +543,24 @@ func ProgressHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func runCgWithProgressCapture(cmd *exec.Cmd, sendProgress func(string)) ([]byte, error) {
-	// Create pipes for stdout and stderr
+func runCgWithProgressCapture(cmd *exec.Cmd, sendProgress func(string)) (output []byte, logs []byte, err error) {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Start the command
 	if err := cmd.Start(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var outputBuffer strings.Builder
+	var logsBuffer strings.Builder
 	var wg sync.WaitGroup
 
-	// Read stdout
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -562,7 +571,6 @@ func runCgWithProgressCapture(cmd *exec.Cmd, sendProgress func(string)) ([]byte,
 		}
 	}()
 
-	// Read stderr (progress output)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -570,14 +578,14 @@ func runCgWithProgressCapture(cmd *exec.Cmd, sendProgress func(string)) ([]byte,
 		for scanner.Scan() {
 			line := scanner.Text()
 			sendProgress(line)
+			logsBuffer.WriteString(line + "\n")
 		}
 	}()
 
-	// Wait for command to finish
 	err = cmd.Wait()
 	wg.Wait()
 
-	return []byte(outputBuffer.String()), err
+	return []byte(outputBuffer.String()), []byte(logsBuffer.String()), err
 }
 
 func runGovulncheckWithProgress(directory, target string, sendProgress func(string)) (string, int, error) {

--- a/site/index.html
+++ b/site/index.html
@@ -13,7 +13,7 @@
 		<div class="gvs-topbar-brand">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196 145" width="24" height="18" aria-hidden="true" role="img"><path d="M127.47 83.49c12.51 0 30.61-2.58 30.61-17.46a14 14 0 0 0-.31-3.42l-7.45-32.36c-1.72-7.12-3.23-10.35-15.73-16.6C124.89 8.69 103.76.5 97.51.5 91.69.5 90 8 83.06 8c-6.68 0-11.64-5.6-17.89-5.6-6 0-9.91 4.09-12.93 12.5 0 0-8.41 23.72-9.49 27.16A6.43 6.43 0 0 0 42.53 44c0 9.22 36.3 39.45 84.94 39.45M160 72.07c1.73 8.19 1.73 9.05 1.73 10.13 0 14-15.74 21.77-36.43 21.77C78.54 104 37.58 76.6 37.58 58.49a18.45 18.45 0 0 1 1.51-7.33C22.27 52 .5 55 .5 74.22c0 31.48 74.59 70.28 133.65 70.28 45.28 0 56.7-20.48 56.7-36.65 0-12.72-11-27.16-30.83-35.78" fill="#e00"/><path d="M160 72.07c1.73 8.19 1.73 9.05 1.73 10.13 0 14-15.74 21.77-36.43 21.77C78.54 104 37.58 76.6 37.58 58.49a18.45 18.45 0 0 1 1.51-7.33l3.66-9.06A6.43 6.43 0 0 0 42.53 44c0 9.22 36.3 39.45 84.94 39.45 12.51 0 30.61-2.58 30.61-17.46a14 14 0 0 0-.31-3.42" fill="#000"/></svg>
 			<span style="font-size:var(--pf-t--global--font--size--heading--h2); white-space:nowrap; font-weight:700;">Golang Vulnerability Scanner</span>
-			<span style="background:#ee0000; color:#fff; font-size:0.75rem; font-weight:700; line-height:1; padding:0.2rem 0.5rem; border-radius:1rem; letter-spacing:0.03em; align-self:center;">OCP SE</span>
+			<span style="background:#ee0000; color:#fff; font-size:0.75rem; font-weight:700; line-height:1; padding:0.2rem 0.5rem; border-radius:1rem; letter-spacing:0.03em; align-self:center;">AI</span>
 		</div>
 		<nav class="gvs-nav">
 			<a href="#" class="gvs-nav-link gvs-nav-active" data-view="scanner" onclick="showView('scanner',event)">New Scan</a>
@@ -82,12 +82,25 @@
 				<div class="gvs-col gvs-col-ref">
 					<h3 class="gvs-section-title">Frequently Asked Questions</h3>
 					<dl class="gvs-ref-list">
+						<div class="gvs-ref-item"><dt>What does the GVS scanner analysis do?</dt><dd>It traces whether vulnerable symbols are actually reachable from your code's entry points using call graph analysis, then Claude AI independently verifies the result by inspecting source code, interface implementations, and caller chains to catch false positives and false negatives.</dd></div>
 						<div class="gvs-ref-item"><dt>What algorithms are available?</dt><dd>VTA (most precise, slowest), RTA (balanced), CHA (fast, less precise), Static (fastest, direct calls only)</dd></div>
-						<div class="gvs-ref-item"><dt>What is a CVE vs Go CVE ID?</dt><dd>CVE-YYYY-NNNNN is the standard ID. GO-YYYY-NNNN is Go's own advisory ID. Both are accepted.</dd></div>
-						<div class="gvs-ref-item"><dt>Do I need Library/Symbol/Fix Version?</dt><dd>Only if bypassing CVE lookup. All three must be provided together.</dd></div>
-						<div class="gvs-ref-item"><dt>Does this tool modify my repository?</dt><dd>No. It clones a read-only copy for analysis. Your source code is never changed.</dd></div>
+						<div class="gvs-ref-item"><dt>How is the final verdict determined?</dt><dd>The repository is confirmed vulnerable only when both GVS scanner and Claude AI independently agree. If either disagrees, the result is treated as not confirmed.
+							<table style="margin-top:0.5rem; border-collapse:collapse; width:100%; font-size:0.85rem;">
+								<thead><tr style="border-bottom:2px solid var(--pf-t--global--border--color--default);">
+									<th style="padding:0.3rem 0.5rem; text-align:left;">GVS Scanner</th>
+									<th style="padding:0.3rem 0.5rem; text-align:left; border-left:1px solid var(--pf-t--global--border--color--default);">Claude AI</th>
+									<th style="padding:0.3rem 0.5rem; text-align:left; border-left:1px solid var(--pf-t--global--border--color--default);">Final Verdict</th>
+								</tr></thead>
+								<tbody>
+									<tr style="background:rgba(200,0,0,0.08);"><td style="padding:0.3rem 0.5rem; color:#c9190b;">Vulnerable</td><td style="padding:0.3rem 0.5rem; border-left:1px solid var(--pf-t--global--border--color--default); color:#3e8635;">Agrees</td><td style="padding:0.3rem 0.5rem; border-left:1px solid var(--pf-t--global--border--color--default); color:#c9190b;"><strong>Vulnerable</strong></td></tr>
+									<tr style="background:rgba(62,134,53,0.08);"><td style="padding:0.3rem 0.5rem; color:#3e8635;">Not Vulnerable</td><td style="padding:0.3rem 0.5rem; border-left:1px solid var(--pf-t--global--border--color--default); color:#3e8635;">Agrees</td><td style="padding:0.3rem 0.5rem; border-left:1px solid var(--pf-t--global--border--color--default); color:#3e8635;"><strong>Not Vulnerable</strong></td></tr>
+									<tr style="background:rgba(62,134,53,0.08);"><td style="padding:0.3rem 0.5rem; color:#c9190b;">Vulnerable</td><td style="padding:0.3rem 0.5rem; border-left:1px solid var(--pf-t--global--border--color--default); color:#c9190b;">Disagrees</td><td style="padding:0.3rem 0.5rem; border-left:1px solid var(--pf-t--global--border--color--default); color:#3e8635;"><strong>Not Vulnerable</strong></td></tr>
+									<tr style="background:rgba(200,0,0,0.08);"><td style="padding:0.3rem 0.5rem; color:#3e8635;">Not Vulnerable</td><td style="padding:0.3rem 0.5rem; border-left:1px solid var(--pf-t--global--border--color--default); color:#c9190b;">Disagrees</td><td style="padding:0.3rem 0.5rem; border-left:1px solid var(--pf-t--global--border--color--default); color:#c9190b;"><strong>Vulnerable</strong></td></tr>
+								</tbody>
+							</table>
+						</dd></div>
 						<div class="gvs-ref-item"><dt>How long does a scan take?</dt><dd>Typically 2-10 minutes depending on repository size and algorithm chosen.</dd></div>
-						<div class="gvs-ref-item"><dt>What does the call graph analysis do?</dt><dd>It traces whether vulnerable symbols are actually reachable from your code's entry points, reducing false positives.</dd></div>
+						<div class="gvs-ref-item"><dt>Do I need Library/Symbol/Fix Version?</dt><dd>Only if bypassing CVE lookup. All three must be provided together.</dd></div>
 					</dl>
 				</div>
 			</div>
@@ -99,13 +112,19 @@
 		<div class="gvs-main-card gvs-result-card">
 			<div class="gvs-result-split">
 				<div class="gvs-result-pane gvs-log-pane">
-					<h3 class="gvs-pane-title">Progress Log</h3>
+					<div class="gvs-pane-header">
+						<h3 class="gvs-pane-title">Progress Log</h3>
+						<button class="gvs-copy-btn" onclick="copyPaneContent(this, 'resultProgressContent')">Copy</button>
+					</div>
 					<div id="resultProgressContent" class="gvs-log-output">
 						<div class="gvs-log-placeholder">Progress will appear here when a scan starts.</div>
 					</div>
 				</div>
 				<div class="gvs-result-pane gvs-output-pane">
-					<h3 class="gvs-pane-title">Scan Result</h3>
+					<div class="gvs-pane-header">
+						<h3 class="gvs-pane-title">Scan Result</h3>
+						<button class="gvs-copy-btn" onclick="copyPaneContent(this, 'output')">Copy</button>
+					</div>
 					<div id="output" class="gvs-scan-output">
 						<div class="gvs-log-placeholder">Scan results will appear here after completion.</div>
 					</div>

--- a/site/index.html
+++ b/site/index.html
@@ -4,137 +4,154 @@
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Golang Vulnerability Scanner</title>
-		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+		<link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@6/patternfly.min.css">
 		<link href="styles.css" rel="stylesheet">
 	</head>
-	<body class="container mt-5">
-		<!-- Dark Mode Toggle Button -->
-		<button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-			<span id="themeIcon" class="theme-icon moon"></span>
-		</button>
-		
-		<h2 class="text-center">Golang Vulnerability Scanner</h2>
-		<p class="text-center text-muted">Analyze your Golang-based repository for vulnerabilities</p>	
-		<div class="card p-3 shadow-sm mb-4">
-			<code class="d-block rounded p-3 text-start" style="font-size: 0.9em;">
-				Important fields that need to be checked in the JSON output<br><br>
-				<strong>IsVulnerable:</strong> It has three values - true, false, and unknown. If it is true, then the repository is vulnerable to the CVE ID. If it is false, then the repository is not vulnerable to the CVE ID. If it is unknown, then the scanning is failed.<br>
-				<strong>AffectedImports:</strong> It is a list of symbols that are affected by the CVE ID. It contains information about the symbol's name, version, and its library name.<br>
-				<strong>UsedImports:</strong> It is a list of symbols that are used in the repository. If it is empty, then the repository is not vulnerable to the CVE ID.<br>
-				<strong>ClaudeVerification:</strong> Independent AI audit by Claude. Contains verdict (agrees_with_scanner), assessment, confidence, concise reasoning, and file:line evidence.<br>
-			</code>
+	<body class="gvs-body">
+
+	<header class="gvs-topbar">
+		<div class="gvs-topbar-brand">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196 145" width="24" height="18" aria-hidden="true" role="img"><path d="M127.47 83.49c12.51 0 30.61-2.58 30.61-17.46a14 14 0 0 0-.31-3.42l-7.45-32.36c-1.72-7.12-3.23-10.35-15.73-16.6C124.89 8.69 103.76.5 97.51.5 91.69.5 90 8 83.06 8c-6.68 0-11.64-5.6-17.89-5.6-6 0-9.91 4.09-12.93 12.5 0 0-8.41 23.72-9.49 27.16A6.43 6.43 0 0 0 42.53 44c0 9.22 36.3 39.45 84.94 39.45M160 72.07c1.73 8.19 1.73 9.05 1.73 10.13 0 14-15.74 21.77-36.43 21.77C78.54 104 37.58 76.6 37.58 58.49a18.45 18.45 0 0 1 1.51-7.33C22.27 52 .5 55 .5 74.22c0 31.48 74.59 70.28 133.65 70.28 45.28 0 56.7-20.48 56.7-36.65 0-12.72-11-27.16-30.83-35.78" fill="#e00"/><path d="M160 72.07c1.73 8.19 1.73 9.05 1.73 10.13 0 14-15.74 21.77-36.43 21.77C78.54 104 37.58 76.6 37.58 58.49a18.45 18.45 0 0 1 1.51-7.33l3.66-9.06A6.43 6.43 0 0 0 42.53 44c0 9.22 36.3 39.45 84.94 39.45 12.51 0 30.61-2.58 30.61-17.46a14 14 0 0 0-.31-3.42" fill="#000"/></svg>
+			<span style="font-size:var(--pf-t--global--font--size--heading--h2); white-space:nowrap; font-weight:700;">Golang Vulnerability Scanner</span>
+			<span style="background:#ee0000; color:#fff; font-size:0.75rem; font-weight:700; line-height:1; padding:0.2rem 0.5rem; border-radius:1rem; letter-spacing:0.03em; align-self:center;">OCP SE</span>
 		</div>
-		<div class="card p-4 shadow-sm expandable-card" onclick="handleCardClick(event)">
-			<div class="card-header-section">
-				<div class="row mb-3 align-items-end">
-					<div class="col-md-5">
-						<label for="repo" class="form-label">
-							Repository URL
-							<span class="d-inline-flex align-items-center justify-content-center ms-1 text-muted" 
-								  style="width: 16px; height: 16px; border-radius: 50%; border: 1px solid #6c757d; font-size: 11px; cursor: help; vertical-align: middle; transform: translateY(-2px);"
-								  data-bs-toggle="tooltip" data-bs-placement="top" 
-								  title="Git repository URL from GitHub, GitLab, Bitbucket, etc. Must be publicly accessible.">?</span>
-						</label>
-						<input type="text" id="repo" class="form-control" placeholder="Enter repo URL" value="https://github.com/openshift/sriov-network-device-plugin">
-					</div>
-					<div class="col-md-2">
-						<label for="branchOrCommit" class="form-label">
-							Branch or Commit ID
-							<span class="d-inline-flex align-items-center justify-content-center ms-1 text-muted" 
-								  style="width: 16px; height: 16px; border-radius: 50%; border: 1px solid #6c757d; font-size: 11px; cursor: help; vertical-align: middle; transform: translateY(-2px);"
-								  data-bs-toggle="tooltip" data-bs-placement="top" 
-								  title="Branch name (e.g., main, master, develop) or commit hash (e.g., abc123f, 1a2b3c4d5e6f7a8b). For commit hashes, use 7+ character SHA hashes for reliable detection.">?</span>
-						</label>
-						<input type="text" id="branchOrCommit" class="form-control" placeholder="Branch or commit id" value="release-4.18">
-					</div>
-				<div class="col-md-2">
-					<label for="cve" class="form-label">
-						CVE ID (optional)
-						<span class="d-inline-flex align-items-center justify-content-center ms-1 text-muted" 
-							  style="width: 16px; height: 16px; border-radius: 50%; border: 1px solid #6c757d; font-size: 11px; cursor: help; vertical-align: middle; transform: translateY(-2px);"
-							  data-bs-toggle="tooltip" data-bs-placement="top" 
-							  title="Enter either a CVE ID (e.g., CVE-2024-45338) or GOCVE ID (e.g., GO-2024-3333). If left empty, scans for all known Go vulnerabilities in the repository.">?</span>
-					</label>
-					<input type="text" id="cve" class="form-control" placeholder="Enter CVE ID or GOCVE ID" value="CVE-2024-45339">
+		<nav class="gvs-nav">
+			<a href="#" class="gvs-nav-link gvs-nav-active" data-view="scanner" onclick="showView('scanner',event)">New Scan</a>
+			<a href="#" class="gvs-nav-link" data-view="result" onclick="showView('result',event)">Result</a>
+			<a href="#" class="gvs-nav-link" data-view="history" onclick="showView('history',event)">Scan History</a>
+		</nav>
+	</header>
+
+	<!-- Scanner View -->
+	<div id="scanner-view" class="gvs-view">
+		<div class="gvs-main-card gvs-gopher-bg">
+			<div class="gvs-card-body gvs-two-col">
+				<div class="gvs-col gvs-col-form">
+					<h1 class="gvs-section-title">Scan Configuration</h1>
+					<form class="pf-v6-c-form" onsubmit="return false;">
+						<div class="pf-v6-c-form__group">
+							<div class="pf-v6-c-form__group-label">
+								<label class="pf-v6-c-form__label" for="repo">
+									<span class="pf-v6-c-form__label-text">Repository URL</span>
+								</label>
+							</div>
+							<div class="pf-v6-c-form__group-control">
+								<span class="pf-v6-c-form-control"><input type="text" id="repo" placeholder="https://github.com/org/repo" value="https://github.com/openshift/sriov-network-device-plugin"></span>
+							</div>
+						</div>
+						<div class="pf-v6-l-grid pf-m-gutter">
+							<div class="pf-v6-l-grid__item pf-m-6-col-on-md">
+								<div class="pf-v6-c-form__group">
+									<div class="pf-v6-c-form__group-label"><label class="pf-v6-c-form__label" for="branchOrCommit"><span class="pf-v6-c-form__label-text">Branch / Commit</span></label></div>
+									<div class="pf-v6-c-form__group-control"><span class="pf-v6-c-form-control"><input type="text" id="branchOrCommit" placeholder="e.g., main, release-4.18" value="release-4.18"></span></div>
+								</div>
+							</div>
+							<div class="pf-v6-l-grid__item pf-m-6-col-on-md">
+								<div class="pf-v6-c-form__group">
+									<div class="pf-v6-c-form__group-label"><label class="pf-v6-c-form__label" for="cve"><span class="pf-v6-c-form__label-text">CVE ID / Go CVE ID</span></label></div>
+									<div class="pf-v6-c-form__group-control"><span class="pf-v6-c-form-control"><input type="text" id="cve" placeholder="CVE-2024-XXXXX" value="CVE-2024-45339"></span></div>
+								</div>
+							</div>
+						</div>
+						<div class="pf-v6-c-form__group">
+							<div class="pf-v6-c-form__group-label"><label class="pf-v6-c-form__label" for="algo"><span class="pf-v6-c-form__label-text">Algorithm</span></label></div>
+							<div class="pf-v6-c-form__group-control"><span class="pf-v6-c-form-control"><select id="algo"><option value="rta" selected>RTA</option><option value="vta">VTA</option><option value="cha">CHA</option><option value="static">Static</option></select></span></div>
+						</div>
+						<details class="gvs-advanced">
+							<summary>Advanced options</summary>
+							<div class="gvs-advanced-fields">
+								<div class="pf-v6-c-form__group">
+									<div class="pf-v6-c-form__group-label"><label class="pf-v6-c-form__label" for="library"><span class="pf-v6-c-form__label-text">Library</span></label></div>
+									<div class="pf-v6-c-form__group-control"><span class="pf-v6-c-form-control"><input type="text" id="library" placeholder="e.g., golang.org/x/net/html"></span></div>
+								</div>
+								<div class="pf-v6-c-form__group">
+									<div class="pf-v6-c-form__group-label"><label class="pf-v6-c-form__label" for="symbol"><span class="pf-v6-c-form__label-text">Symbol</span></label></div>
+									<div class="pf-v6-c-form__group-control"><span class="pf-v6-c-form-control"><input type="text" id="symbol" placeholder="e.g., Parse, Render"></span></div>
+								</div>
+								<div class="pf-v6-c-form__group">
+									<div class="pf-v6-c-form__group-label"><label class="pf-v6-c-form__label" for="fixversion"><span class="pf-v6-c-form__label-text">Fixed Version</span></label></div>
+									<div class="pf-v6-c-form__group-control"><span class="pf-v6-c-form-control"><input type="text" id="fixversion" placeholder="e.g., v1.9.4"></span></div>
+								</div>
+							</div>
+						</details>
+						<div class="pf-v6-c-form__group">
+							<button id="scanButton" class="pf-v6-c-button pf-m-primary pf-m-block" type="button" onclick="runScan()">Run Scan</button>
+						</div>
+					</form>
 				</div>
-				<div class="col-md-1">
-					<label for="algo" class="form-label">
-						Algo
-						<span class="d-inline-flex align-items-center justify-content-center ms-1 text-muted"
-							  style="width: 16px; height: 16px; border-radius: 50%; border: 1px solid #6c757d; font-size: 11px; cursor: help; vertical-align: middle; transform: translateY(-2px);"
-							  data-bs-toggle="tooltip" data-bs-placement="top"
-							  title="Call graph algorithm: RTA (default, best for reflection), VTA (precise but slower), CHA (fast but less precise), Static (fastest, direct calls only).">?</span>
-					</label>
-					<select id="algo" class="form-select">
-						<option value="rta" selected>RTA</option>
-						<option value="vta">VTA</option>
-						<option value="cha">CHA</option>
-						<option value="static">Static</option>
-					</select>
-				</div>
-				<div class="col-md-2 text-end">
-					<button id="scanButton" class="btn btn-primary w-100" onclick="runScan()">Run Scan</button>
-				</div>
-			</div>
-			<div class="row mb-3 align-items-end">
-				<div class="col-md-4">
-					<label for="library" class="form-label">
-						Library (optional)
-						<span class="d-inline-flex align-items-center justify-content-center ms-1 text-muted"
-							  style="width: 16px; height: 16px; border-radius: 50%; border: 1px solid #6c757d; font-size: 11px; cursor: help; vertical-align: middle; transform: translateY(-2px);"
-							  data-bs-toggle="tooltip" data-bs-placement="top"
-							  title="Specify a library path to scan (e.g., golang.org/x/net/html). When provided with Symbol, this takes precedence over CVE-based scanning.">?</span>
-					</label>
-					<input type="text" id="library" class="form-control" placeholder="e.g., golang.org/x/net/html">
-				</div>
-				<div class="col-md-5">
-					<label for="symbol" class="form-label">
-						Symbol (optional)
-						<span class="d-inline-flex align-items-center justify-content-center ms-1 text-muted"
-							  style="width: 16px; height: 16px; border-radius: 50%; border: 1px solid #6c757d; font-size: 11px; cursor: help; vertical-align: middle; transform: translateY(-2px);"
-							  data-bs-toggle="tooltip" data-bs-placement="top"
-							  title="Specify a symbol name to scan for (e.g., Parse, Render). Multiple symbols can be comma-separated. Used with Library field.">?</span>
-					</label>
-					<input type="text" id="symbol" class="form-control" placeholder="e.g., Parse, Render">
-				</div>
-				<div class="col-md-3">
-					<label for="fixversion" class="form-label">
-						Fixed Version (optional)
-						<span class="d-inline-flex align-items-center justify-content-center ms-1 text-muted"
-							  style="width: 16px; height: 16px; border-radius: 50%; border: 1px solid #6c757d; font-size: 11px; cursor: help; vertical-align: middle; transform: translateY(-2px);"
-							  data-bs-toggle="tooltip" data-bs-placement="top"
-							  title="Specify the fixed version for manual scans (e.g., v1.9.4). Used with Library and Symbol fields for version comparison.">?</span>
-					</label>
-					<input type="text" id="fixversion" class="form-control" placeholder="e.g., v1.9.4">
-				</div>
-				</div>
-			</div>
-			
-			<!-- Integrated Progress Section -->
-			<div class="progress-section">
-				<div id="progressContent" class="progress-content collapsed">
-					<div class="progress-placeholder">Server progress will appear here during scans. Progress from previous scans is preserved until the next scan starts.</div>
+				<div class="gvs-col gvs-col-ref">
+					<h3 class="gvs-section-title">Frequently Asked Questions</h3>
+					<dl class="gvs-ref-list">
+						<div class="gvs-ref-item"><dt>What algorithms are available?</dt><dd>VTA (most precise, slowest), RTA (balanced), CHA (fast, less precise), Static (fastest, direct calls only)</dd></div>
+						<div class="gvs-ref-item"><dt>What is a CVE vs Go CVE ID?</dt><dd>CVE-YYYY-NNNNN is the standard ID. GO-YYYY-NNNN is Go's own advisory ID. Both are accepted.</dd></div>
+						<div class="gvs-ref-item"><dt>Do I need Library/Symbol/Fix Version?</dt><dd>Only if bypassing CVE lookup. All three must be provided together.</dd></div>
+						<div class="gvs-ref-item"><dt>Does this tool modify my repository?</dt><dd>No. It clones a read-only copy for analysis. Your source code is never changed.</dd></div>
+						<div class="gvs-ref-item"><dt>How long does a scan take?</dt><dd>Typically 2-10 minutes depending on repository size and algorithm chosen.</dd></div>
+						<div class="gvs-ref-item"><dt>What does the call graph analysis do?</dt><dd>It traces whether vulnerable symbols are actually reachable from your code's entry points, reducing false positives.</dd></div>
+					</dl>
 				</div>
 			</div>
 		</div>
-	<div id="output" class="result-card"></div>
-	<div id="reportContainer" class="report-container" style="display: none;">
-		<button id="reportButton" class="btn btn-outline-secondary btn-sm" onclick="reportInaccuracy()">
-			Report Inaccuracy
-		</button>
 	</div>
+
+	<!-- Result View -->
+	<div id="result-view" class="gvs-view" style="display:none">
+		<div class="gvs-main-card gvs-result-card">
+			<div class="gvs-result-split">
+				<div class="gvs-result-pane gvs-log-pane">
+					<h3 class="gvs-pane-title">Progress Log</h3>
+					<div id="resultProgressContent" class="gvs-log-output">
+						<div class="gvs-log-placeholder">Progress will appear here when a scan starts.</div>
+					</div>
+				</div>
+				<div class="gvs-result-pane gvs-output-pane">
+					<h3 class="gvs-pane-title">Scan Result</h3>
+					<div id="output" class="gvs-scan-output">
+						<div class="gvs-log-placeholder">Scan results will appear here after completion.</div>
+					</div>
+					<div id="reportContainer" style="display:none; margin-top:8px; text-align:right;">
+						<button class="pf-v6-c-button pf-m-link pf-m-small" type="button" onclick="openFeedbackModal()">Feedback for Claude</button>
+						<button id="reportButton" class="pf-v6-c-button pf-m-link pf-m-small" type="button" onclick="reportInaccuracy()">Report Inaccuracy</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- History View -->
+	<div id="history-view" class="gvs-view" style="display:none">
+		<div class="gvs-main-card">
+			<div class="gvs-card-header">
+				<div style="display:flex;justify-content:space-between;align-items:center">
+					<h1 class="gvs-card-title">Scan History</h1>
+					<button class="pf-v6-c-button pf-m-danger pf-m-small" type="button" onclick="clearScanHistory()">Clear All</button>
+				</div>
+				<p class="gvs-card-desc">Previously completed scans stored in your browser.</p>
+			</div>
+			<div class="gvs-card-body" id="historyCardBody">
+				<div class="pf-v6-c-empty-state">
+					<div class="pf-v6-c-empty-state__content">
+						<div class="pf-v6-c-empty-state__body">No scan history yet. Run a scan to see results here.</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Feedback Modal -->
+	<div id="feedbackModal" class="gvs-modal-overlay" style="display:none" onclick="closeFeedbackModal(event)">
+		<div class="gvs-modal">
+			<h3 class="gvs-modal-title">Feedback for Claude</h3>
+			<p class="gvs-modal-desc">How does GVS scan result compare with Claude's verification?</p>
+			<div class="gvs-modal-actions">
+				<button class="pf-v6-c-button pf-m-secondary" type="button" onclick="submitFeedback('gvs_only')">GVS was right</button>
+				<button class="pf-v6-c-button pf-m-secondary" type="button" onclick="submitFeedback('claude_only')">Claude was right</button>
+				<button class="pf-v6-c-button pf-m-primary" type="button" onclick="submitFeedback('both')">Both were right</button>
+			</div>
+		</div>
+	</div>
+
 	<script src="config.js"></script>
-		<script src="script.js"></script>
-		<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-		<script>
-			// Initialize Bootstrap tooltips
-			document.addEventListener('DOMContentLoaded', function () {
-				var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
-				var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
-					return new bootstrap.Tooltip(tooltipTriggerEl);
-				});
-			});
-		</script>
-		<footer class="mt-5 pb-4 text-center text-muted">&copy; 2025 Golang Vulnerability Scanner</footer>
+	<script src="script.js"></script>
 	</body>
 </html>

--- a/site/script.js
+++ b/site/script.js
@@ -106,41 +106,74 @@ class FormHistoryManager {
 	}
 }
 
-// Dark Mode Toggle Functionality
-class ThemeManager {
-	constructor() {
-		this.themeToggle = document.getElementById('themeToggle');
-		this.themeIcon = document.getElementById('themeIcon');
-		this.currentTheme = localStorage.getItem('theme') || 'light';
-		
-		this.init();
+// View switching
+function showView(name, event) {
+	if (event) event.preventDefault();
+	['scanner', 'result', 'history'].forEach(v => {
+		document.getElementById(v + '-view').style.display = v === name ? '' : 'none';
+	});
+	document.querySelectorAll('.gvs-nav-link').forEach(l => {
+		l.classList.toggle('gvs-nav-active', l.dataset.view === name);
+	});
+	if (name === 'history') renderScanHistory();
+}
+
+function showScannerView(event) { showView('scanner', event); }
+function showHistoryView(event) { showView('history', event); }
+function showResultView(event) { showView('result', event); }
+
+// Scan history management
+function saveScanToHistory(scanData) {
+	let history = JSON.parse(localStorage.getItem('gvs-scan-history') || '[]');
+	history.unshift({ ...scanData, timestamp: new Date().toISOString() });
+	if (history.length > 50) history = history.slice(0, 50);
+	localStorage.setItem('gvs-scan-history', JSON.stringify(history));
+}
+
+function clearScanHistory() {
+	localStorage.removeItem('gvs-scan-history');
+	renderScanHistory();
+}
+
+function renderScanHistory() {
+	const body = document.getElementById('historyCardBody');
+	const history = JSON.parse(localStorage.getItem('gvs-scan-history') || '[]');
+	if (!history.length) {
+		body.innerHTML = '<div class="pf-v6-c-empty-state"><div class="pf-v6-c-empty-state__content"><div class="pf-v6-c-empty-state__body">No scan history yet. Run a scan to see results here.</div></div></div>';
+		return;
 	}
-	
-	init() {
-		this.applyTheme(this.currentTheme);
-		this.themeToggle.addEventListener('click', () => this.toggleTheme());
+	let html = '<table class="gvs-history-table"><thead><tr><th>Date</th><th>Repository</th><th>Branch</th><th>CVE</th><th>Status</th><th>Feedback</th><th></th></tr></thead><tbody>';
+	history.forEach((item, i) => {
+		const date = new Date(item.timestamp).toLocaleDateString();
+		const repo = item.repo || '';
+		const branch = item.branchOrCommit || '-';
+		const vuln = String(item.isVulnerable).toLowerCase();
+		let label = '<span class="gvs-label gvs-label-warning">unknown</span>';
+		if (vuln === 'true') label = '<span class="gvs-label gvs-label-danger">true</span>';
+		else if (vuln === 'false') label = '<span class="gvs-label gvs-label-success">false</span>';
+		const feedback = item.feedback || '-';
+		html += `<tr><td>${date}</td><td>${repo}</td><td>${branch}</td><td>${item.cve || '-'}</td><td>${label}</td><td>${feedback}</td><td><button class="pf-v6-c-button pf-m-link pf-m-small" onclick="loadHistoryScan(${i})">View</button></td></tr>`;
+	});
+	html += '</tbody></table>';
+	body.innerHTML = html;
+}
+
+function loadHistoryScan(index) {
+	const history = JSON.parse(localStorage.getItem('gvs-scan-history') || '[]');
+	const item = history[index];
+	if (!item) return;
+	showResultView();
+	const outputDiv = document.getElementById('output');
+	const progressContent = document.getElementById('resultProgressContent');
+	progressContent.innerHTML = 'Loaded from scan history.\n';
+	if (item.output) {
+		outputDiv.innerHTML = `<pre>${syntaxHighlight(JSON.stringify(item.output, null, 2))}</pre>`;
 	}
-	
-	toggleTheme() {
-		this.currentTheme = this.currentTheme === 'light' ? 'dark' : 'light';
-		this.applyTheme(this.currentTheme);
-		localStorage.setItem('theme', this.currentTheme);
-	}
-	
-	applyTheme(theme) {
-		document.documentElement.setAttribute('data-theme', theme);
-		this.themeIcon.className = theme === 'light' ? 'theme-icon moon' : 'theme-icon sun';
-		this.themeToggle.setAttribute('aria-label', 
-			theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'
-		);
-	}
+	document.getElementById("reportContainer").style.display = "block";
 }
 
 // Initialize all components on DOM content loaded
 document.addEventListener('DOMContentLoaded', function() {
-	// Initialize theme manager
-	new ThemeManager();
-	
 	// Initialize form history manager
 	window.formHistory = new FormHistoryManager();
 	
@@ -288,12 +321,14 @@ function runScan() {
 	const algo = document.getElementById("algo").value;
 	const graph = !!(cve || (library && symbol));
 	const outputDiv = document.getElementById("output");
-	const progressContent = document.getElementById("progressContent");
+	const progressContent = document.getElementById("resultProgressContent");
 	const scanButton = document.getElementById("scanButton");
 
-	outputDiv.style.display = "none";
-	outputDiv.className = "result-card";
-	outputDiv.innerHTML = "";
+	// Switch to Result view
+	showResultView();
+
+	outputDiv.className = "gvs-scan-output";
+	outputDiv.innerHTML = '<div class="gvs-log-placeholder">Waiting for results...</div>';
 	
 	// Hide report button when starting a new scan
 	document.getElementById("reportContainer").style.display = "none";
@@ -301,8 +336,6 @@ function runScan() {
 	// Clear previous progress output and initialize new scan
 	const timestamp = new Date().toLocaleTimeString();
 	progressContent.innerHTML = `Scan Started at ${timestamp}\nInitializing scan...\n`;
-	// Auto-expand progress card when scan starts
-	expandProgressCard();
 	
 	scanButton.disabled = true;
 	scanButton.innerText = "Scanning...";
@@ -335,10 +368,7 @@ function runScan() {
 
 	// Use callgraph endpoint if CVE is provided, or if library and symbol are provided for direct scanning
 	if (repo && branchOrCommit && (cve || (library && symbol))) {
-		const hostUrl = `${location.protocol}//${location.host}`;
 		outputDiv.innerHTML = getRandomSustainingQuestion();
-		outputDiv.classList.add("alert-warning");
-		outputDiv.style.display = "block";
 
 		fetch(`${API_BASE_URL}/callgraph`, {
 			method: "POST",
@@ -379,9 +409,6 @@ function runScan() {
 		const timeoutId = setTimeout(() => controller.abort(), 360000);
 
 		outputDiv.innerHTML = getRandomSustainingQuestion();
-		outputDiv.classList.remove("alert-success", "alert-danger", "alert-warning");
-		outputDiv.classList.add("alert-warning");
-		outputDiv.style.display = "block";
 
 		fetch(`${API_BASE_URL}/scan`, {
 			method: "POST",
@@ -412,8 +439,6 @@ function runScan() {
 					? "Request timed out (360 sec)"
 					: error.message || error;
 				outputDiv.innerHTML = `<strong>Error:</strong> ${errMsg}`;
-				outputDiv.classList.add("alert-danger");
-				outputDiv.style.display = "block";
 				
 				// Add error message to progress output
 				progressContent.innerHTML += `Network Error: ${errMsg}\n`;
@@ -426,7 +451,7 @@ function runScan() {
 
 	function pollStatus(taskId, showProgress) {
 		const pollInterval = 3000;
-		const progressContent = document.getElementById("progressContent");
+		const progressContent = document.getElementById("resultProgressContent");
 		
 		// Always start progress streaming
 		startProgressStream(taskId);
@@ -442,12 +467,10 @@ function runScan() {
 				.then(response => response.json())
 				.then(statusData => {
 					if (statusData.error) {
-						outputDiv.innerHTML = "";
 						outputDiv.innerHTML = `<strong>Error:</strong> ${statusData.error}<br>`;
-						outputDiv.classList.add("alert-danger");
 						
 						// Add error message to progress output
-						const progressContent = document.getElementById("progressContent");
+						const progressContent = document.getElementById("resultProgressContent");
 						const timestamp = new Date().toLocaleTimeString();
 						progressContent.innerHTML += `Scan Failed at ${timestamp}: ${statusData.error}\n`;
 						progressContent.scrollTop = progressContent.scrollHeight;
@@ -458,17 +481,22 @@ function runScan() {
 					}
 
 					if (statusData.status === "completed") {
-						outputDiv.innerHTML = "";
 						outputDiv.innerHTML = `<pre>${syntaxHighlight(JSON.stringify(statusData.output, null, 2))}</pre>`;
-						outputDiv.classList.remove("alert-warning");
-						outputDiv.classList.add("alert-success");
 						clearInterval(intervalId);
 						
 						// Show report inaccuracy button
 						document.getElementById("reportContainer").style.display = "block";
 						
+						saveScanToHistory({
+							repo: document.getElementById("repo").value.trim(),
+							branchOrCommit: document.getElementById("branchOrCommit").value.trim(),
+							cve: document.getElementById("cve").value.trim(),
+							isVulnerable: statusData.output?.IsVulnerable,
+							output: statusData.output
+						});
+						
 						// Add completion message to progress output
-						const progressContent = document.getElementById("progressContent");
+						const progressContent = document.getElementById("resultProgressContent");
 						const timestamp = new Date().toLocaleTimeString();
 						progressContent.innerHTML += `Scan Completed Successfully at ${timestamp}\n`;
 						progressContent.scrollTop = progressContent.scrollHeight;
@@ -485,12 +513,10 @@ function runScan() {
 					outputDiv.scrollTop = outputDiv.scrollHeight;
 				})
 				.catch(err => {
-					outputDiv.innerHTML = "";
-					outputDiv.innerHTML = `<br><strong>Error polling status:</strong> ${err.message}<br>`;
-					outputDiv.classList.add("alert-danger");
+					outputDiv.innerHTML = `<strong>Error polling status:</strong> ${err.message}<br>`;
 					
 					// Add error message to progress output
-					const progressContent = document.getElementById("progressContent");
+					const progressContent = document.getElementById("resultProgressContent");
 					progressContent.innerHTML += `Network Error: ${err.message}\n`;
 					progressContent.scrollTop = progressContent.scrollHeight;
 					
@@ -517,7 +543,7 @@ function runScan() {
 }
 
 function startProgressStream(taskId) {
-	const progressContent = document.getElementById("progressContent");
+	const progressContent = document.getElementById("resultProgressContent");
 
 	// Use Server-Sent Events for real-time progress updates
 	const eventSource = new EventSource(`${API_BASE_URL}/progress/${taskId}`);
@@ -539,45 +565,34 @@ function startProgressStream(taskId) {
 	window.currentProgressStream = eventSource;
 }
 
-function handleCardClick(event) {
-	// Prevent expansion when clicking on form elements
-	const clickableElements = ['INPUT', 'SELECT', 'BUTTON', 'LABEL', 'SPAN'];
-	const isFormElement = clickableElements.includes(event.target.tagName);
-	const isTooltip = event.target.hasAttribute('data-bs-toggle');
-	
-	if (isFormElement || isTooltip) {
-		return;
-	}
-	
-	toggleProgressExpansion();
+function openFeedbackModal() {
+	document.getElementById('feedbackModal').style.display = '';
 }
 
-function toggleProgressExpansion() {
-	const progressContent = document.getElementById("progressContent");
-	
-	if (progressContent.classList.contains("collapsed")) {
-		expandProgressCard();
-	} else {
-		collapseProgressCard();
+function closeFeedbackModal(event) {
+	if (event && event.target === document.getElementById('feedbackModal')) {
+		document.getElementById('feedbackModal').style.display = 'none';
 	}
 }
 
-function expandProgressCard() {
-	const progressContent = document.getElementById("progressContent");
-	progressContent.classList.remove("collapsed");
-}
+function submitFeedback(choice) {
+	document.getElementById('feedbackModal').style.display = 'none';
+	const feedbackLabels = { gvs_only: 'GVS was right', claude_only: 'Claude was right', both: 'Both were right' };
+	const feedbackText = feedbackLabels[choice] || choice;
 
-function collapseProgressCard() {
-	const progressContent = document.getElementById("progressContent");
-	progressContent.classList.add("collapsed");
-}
+	let history = JSON.parse(localStorage.getItem('gvs-scan-history') || '[]');
+	if (history.length > 0) {
+		history[0].feedback = feedbackText;
+		localStorage.setItem('gvs-scan-history', JSON.stringify(history));
+	}
 
-function resetProgressCard() {
-	const progressContent = document.getElementById("progressContent");
-	
-	// Reset to collapsed state with placeholder (only used on page load)
-	collapseProgressCard();
-	progressContent.innerHTML = '<div class="progress-placeholder">Server progress will appear here during scans. Progress from previous scans is preserved until the next scan starts.</div>';
+	const repo = document.getElementById("repo").value.trim();
+	const cve = document.getElementById("cve").value.trim();
+	const labels = { gvs_only: 'gvs-correct', claude_only: 'claude-correct', both: 'both-correct' };
+	const title = `Claude Feedback: ${cve || repo} - ${feedbackText}`;
+	const body = `## Feedback\n- **Choice**: ${feedbackText}\n- **Repository**: ${repo}\n- **CVE**: ${cve || 'N/A'}`;
+	const url = `https://github.com/k37y/gvs/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}&labels=${labels[choice]}`;
+	window.open(url, '_blank');
 }
 
 function reportInaccuracy() {

--- a/site/script.js
+++ b/site/script.js
@@ -142,17 +142,25 @@ function renderScanHistory() {
 		body.innerHTML = '<div class="pf-v6-c-empty-state"><div class="pf-v6-c-empty-state__content"><div class="pf-v6-c-empty-state__body">No scan history yet. Run a scan to see results here.</div></div></div>';
 		return;
 	}
-	let html = '<table class="gvs-history-table"><thead><tr><th>Date</th><th>Repository</th><th>Branch</th><th>CVE</th><th>Status</th><th>Feedback</th><th></th></tr></thead><tbody>';
+	let html = '<table class="gvs-history-table"><thead><tr><th>Date</th><th>Repository</th><th>Branch</th><th>CVE</th><th>Algo</th><th>Status</th><th>AI Agrees</th><th>Feedback</th><th></th></tr></thead><tbody>';
 	history.forEach((item, i) => {
 		const date = new Date(item.timestamp).toLocaleDateString();
 		const repo = item.repo || '';
 		const branch = item.branchOrCommit || '-';
+		const algo = item.algo || '-';
 		const vuln = String(item.isVulnerable).toLowerCase();
 		let label = '<span class="gvs-label gvs-label-warning">unknown</span>';
 		if (vuln === 'true') label = '<span class="gvs-label gvs-label-danger">true</span>';
 		else if (vuln === 'false') label = '<span class="gvs-label gvs-label-success">false</span>';
+		const cv = item.output?.ClaudeVerification;
+		let aiLabel = '<span class="gvs-label gvs-label-warning">-</span>';
+		if (cv) {
+			aiLabel = cv.agrees_with_scanner
+				? '<span class="gvs-label gvs-label-success">Yes</span>'
+				: '<span class="gvs-label gvs-label-danger">No</span>';
+		}
 		const feedback = item.feedback || '-';
-		html += `<tr><td>${date}</td><td>${repo}</td><td>${branch}</td><td>${item.cve || '-'}</td><td>${label}</td><td>${feedback}</td><td><button class="pf-v6-c-button pf-m-link pf-m-small" onclick="loadHistoryScan(${i})">View</button></td></tr>`;
+		html += `<tr><td>${date}</td><td>${repo}</td><td>${branch}</td><td>${item.cve || '-'}</td><td>${algo}</td><td>${label}</td><td>${aiLabel}</td><td>${feedback}</td><td><button class="pf-v6-c-button pf-m-link pf-m-small" onclick="loadHistoryScan(${i})">View</button></td></tr>`;
 	});
 	html += '</tbody></table>';
 	body.innerHTML = html;
@@ -165,7 +173,7 @@ function loadHistoryScan(index) {
 	showResultView();
 	const outputDiv = document.getElementById('output');
 	const progressContent = document.getElementById('resultProgressContent');
-	progressContent.innerHTML = 'Loaded from scan history.\n';
+	progressContent.innerHTML = item.logs || 'Loaded from scan history.\n';
 	if (item.output) {
 		outputDiv.innerHTML = `<pre>${syntaxHighlight(JSON.stringify(item.output, null, 2))}</pre>`;
 	}
@@ -264,6 +272,60 @@ function syntaxHighlight(json) {
 	return json;
 }
 
+function highlightLog(line) {
+	var s = line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+	if (/^\[claude\].*(?:Failed|ERROR|WARNING)/.test(line))
+		return '<span class="log-error">' + s + '</span>';
+	if (/^\[claude\].*tool_call /.test(line))
+		return s.replace(/(tool_call )(\w+)/, '$1<span class="log-tool">$2</span>');
+	if (/^\[claude\]/.test(line))
+		return '<span class="log-claude">' + s + '</span>';
+	if (/✓/.test(line))
+		return '<span class="log-success">' + s + '</span>';
+	if (/✗|Failed|ERROR|^Error:|^Network Error:/.test(line))
+		return '<span class="log-error">' + s + '</span>';
+	if (/WARNING:/.test(line))
+		return '<span class="log-warn">' + s + '</span>';
+	if (/^Scan Completed/.test(line))
+		return '<span class="log-success">' + s + '</span>';
+	if (/^(Scan (?:Started|Failed)|Initializing)/.test(line))
+		return '<span class="log-status">' + s + '</span>';
+	if (/^(Cloning|Clone successful|Running |Found |Discovering)/.test(line))
+		return '<span class="log-info">' + s + '</span>';
+	if (/^Claude verification:/.test(line))
+		return '<span class="log-claude">' + s + '</span>';
+	return s;
+}
+
+function copyPaneContent(btn, elementId) {
+	const el = document.getElementById(elementId);
+	if (!el) return;
+	const text = el.innerText || el.textContent;
+
+	function onSuccess() {
+		btn.classList.add('copied');
+		btn.textContent = 'Copied!';
+		setTimeout(() => {
+			btn.classList.remove('copied');
+			btn.textContent = 'Copy';
+		}, 1500);
+	}
+
+	if (navigator.clipboard && window.isSecureContext) {
+		navigator.clipboard.writeText(text).then(onSuccess);
+	} else {
+		const ta = document.createElement('textarea');
+		ta.value = text;
+		ta.style.position = 'fixed';
+		ta.style.opacity = '0';
+		document.body.appendChild(ta);
+		ta.select();
+		document.execCommand('copy');
+		document.body.removeChild(ta);
+		onSuccess();
+	}
+}
+
 function runScan() {
 	if (scanInProgress) return;
 
@@ -335,7 +397,7 @@ function runScan() {
 	
 	// Clear previous progress output and initialize new scan
 	const timestamp = new Date().toLocaleTimeString();
-	progressContent.innerHTML = `Scan Started at ${timestamp}\nInitializing scan...\n`;
+	progressContent.innerHTML = highlightLog(`Scan Started at ${timestamp}`) + '\n' + highlightLog('Initializing scan...') + '\n';
 	
 	scanButton.disabled = true;
 	scanButton.innerText = "Scanning...";
@@ -384,8 +446,7 @@ function runScan() {
 					outputDiv.innerHTML = `<strong>Error:</strong> ${data.error}<br>`;
 					outputDiv.classList.add("alert-danger");
 					
-					// Add error message to progress output
-					progressContent.innerHTML += `Error: ${data.error}\n`;
+					progressContent.innerHTML += highlightLog(`Error: ${data.error}`) + '\n';
 					progressContent.scrollTop = progressContent.scrollHeight;
 					
 					cleanup()
@@ -399,8 +460,7 @@ function runScan() {
 				outputDiv.innerHTML += `<strong>Network Error:</strong> ${err.message}<br>`;
 				outputDiv.classList.add("alert-danger");
 				
-				// Add error message to progress output
-				progressContent.innerHTML += `Network Error: ${err.message}\n`;
+				progressContent.innerHTML += highlightLog(`Network Error: ${err.message}`) + '\n';
 				progressContent.scrollTop = progressContent.scrollHeight;
 			});
 
@@ -423,8 +483,7 @@ function runScan() {
 					outputDiv.innerHTML = `<strong>Error:</strong> ${data.error}<br>`;
 					outputDiv.classList.add("alert-danger");
 					
-					// Add error message to progress output
-					progressContent.innerHTML += `Error: ${data.error}\n`;
+					progressContent.innerHTML += highlightLog(`Error: ${data.error}`) + '\n';
 					progressContent.scrollTop = progressContent.scrollHeight;
 					
 					cleanup()
@@ -440,8 +499,7 @@ function runScan() {
 					: error.message || error;
 				outputDiv.innerHTML = `<strong>Error:</strong> ${errMsg}`;
 				
-				// Add error message to progress output
-				progressContent.innerHTML += `Network Error: ${errMsg}\n`;
+				progressContent.innerHTML += highlightLog(`Network Error: ${errMsg}`) + '\n';
 				progressContent.scrollTop = progressContent.scrollHeight;
 			})
 			.finally(() => {
@@ -472,7 +530,7 @@ function runScan() {
 						// Add error message to progress output
 						const progressContent = document.getElementById("resultProgressContent");
 						const timestamp = new Date().toLocaleTimeString();
-						progressContent.innerHTML += `Scan Failed at ${timestamp}: ${statusData.error}\n`;
+						progressContent.innerHTML += highlightLog(`Scan Failed at ${timestamp}: ${statusData.error}`) + '\n';
 						progressContent.scrollTop = progressContent.scrollHeight;
 						
 						clearInterval(intervalId);
@@ -486,20 +544,27 @@ function runScan() {
 						
 						// Show report inaccuracy button
 						document.getElementById("reportContainer").style.display = "block";
-						
-						saveScanToHistory({
-							repo: document.getElementById("repo").value.trim(),
-							branchOrCommit: document.getElementById("branchOrCommit").value.trim(),
-							cve: document.getElementById("cve").value.trim(),
-							isVulnerable: statusData.output?.IsVulnerable,
-							output: statusData.output
-						});
-						
-						// Add completion message to progress output
+
+						// Render cached logs if returned by the server (cache hit)
 						const progressContent = document.getElementById("resultProgressContent");
+						if (statusData.logs) {
+							const logLines = statusData.logs.split('\n').filter(l => l).map(l => highlightLog(l));
+							progressContent.innerHTML += logLines.join('\n') + '\n';
+						}
+
 						const timestamp = new Date().toLocaleTimeString();
-						progressContent.innerHTML += `Scan Completed Successfully at ${timestamp}\n`;
+						progressContent.innerHTML += highlightLog(`Scan Completed Successfully at ${timestamp}`) + '\n';
 						progressContent.scrollTop = progressContent.scrollHeight;
+
+					saveScanToHistory({
+						repo: document.getElementById("repo").value.trim(),
+						branchOrCommit: document.getElementById("branchOrCommit").value.trim(),
+						cve: document.getElementById("cve").value.trim(),
+						algo: document.getElementById("algo").value,
+						isVulnerable: statusData.output?.IsVulnerable,
+						output: statusData.output,
+						logs: progressContent.innerHTML
+					});
 						
 						// Close progress stream if active
 						if (window.currentProgressStream) {
@@ -517,7 +582,7 @@ function runScan() {
 					
 					// Add error message to progress output
 					const progressContent = document.getElementById("resultProgressContent");
-					progressContent.innerHTML += `Network Error: ${err.message}\n`;
+					progressContent.innerHTML += highlightLog(`Network Error: ${err.message}`) + '\n';
 					progressContent.scrollTop = progressContent.scrollHeight;
 					
 					clearInterval(intervalId);
@@ -551,7 +616,7 @@ function startProgressStream(taskId) {
 	eventSource.onmessage = function(event) {
 		const data = event.data;
 		if (data && data.trim()) {
-			progressContent.innerHTML += data + '\n';
+			progressContent.innerHTML += highlightLog(data) + '\n';
 			progressContent.scrollTop = progressContent.scrollHeight;
 		}
 	};

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,423 +1,468 @@
-/* CSS Variables for theming */
+/* === GVS Theme === */
 :root {
-	--bg-color: #ffffff;
-	--text-color: #212529;
-	--card-bg: #ffffff;
-	--border-color: #dee2e6;
-	--muted-color: #6c757d;
-	--code-bg: #f8f9fa;
-	--code-color: #212529;
-	--result-card-border: #bbb;
-	--alert-success-bg: #d4edda;
-	--alert-success-border: #5cb85c;
-	--alert-warning-bg: #fff3cd;
-	--alert-warning-border: #f0ad4e;
-	--alert-warning-color: #856404;
-	--alert-danger-bg: #f8d7da;
-	--alert-danger-border: #d9534f;
-	--alert-danger-color: #721c24;
-	--highlight-key-color: #b30000;
-	--highlight-value-color: #007b00;
-	--btn-primary-bg: #0d6efd;
-	--btn-primary-border: #0d6efd;
-	--form-control-bg: #ffffff;
-	--form-control-border: #ced4da;
-	--shadow-color: rgba(0, 0, 0, 0.125);
-	--select-arrow: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23212529' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m1 6 6 6 6-6'/%3e%3c/svg%3e");
+	--gvs-brand: #ee0000;
+	--gvs-brand-hover: #a60000;
+	--gvs-bg: #ededed;
+	--gvs-highlight-key: #b30000;
+	--gvs-highlight-value: #007b00;
+	--gvs-result-border: #bbb;
+	--gvs-code-bg: #f5f5f5;
+	--gvs-alert-success-bg: #d4edda;
+	--gvs-alert-success-border: #5cb85c;
+	--gvs-alert-warning-bg: #fff3cd;
+	--gvs-alert-warning-border: #f0ad4e;
+	--gvs-alert-warning-color: #856404;
+	--gvs-alert-danger-bg: #f8d7da;
+	--gvs-alert-danger-border: #d9534f;
+	--gvs-alert-danger-color: #721c24;
+	--pf-t--global--color--brand--default: var(--gvs-brand);
+	--pf-t--global--color--brand--hover: var(--gvs-brand-hover);
 }
 
-/* Dark mode variables */
-[data-theme="dark"] {
-	--bg-color: #212529;
-	--text-color: #f8f9fa;
-	--card-bg: #343a40;
-	--border-color: #495057;
-	--muted-color: #adb5bd;
-	--code-bg: #2d3748;
-	--code-color: #f8f9fa;
-	--result-card-border: #6c757d;
-	--alert-success-bg: #1e4d2b;
-	--alert-success-border: #28a745;
-	--alert-warning-bg: #5d4e00;
-	--alert-warning-border: #ffc107;
-	--alert-warning-color: #fff3cd;
-	--alert-danger-bg: #5f1a2b;
-	--alert-danger-border: #dc3545;
-	--alert-danger-color: #f8d7da;
-	--highlight-key-color: #ff6b6b;
-	--highlight-value-color: #51cf66;
-	--btn-primary-bg: #0d6efd;
-	--btn-primary-border: #0d6efd;
-	--form-control-bg: #495057;
-	--form-control-border: #6c757d;
-	--shadow-color: rgba(0, 0, 0, 0.3);
-	--select-arrow: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m1 6 6 6 6-6'/%3e%3c/svg%3e");
+/* === Page body === */
+html, body {
+	background: var(--gvs-bg);
+	height: 100%;
+	overflow: hidden;
 }
 
-/* Apply theme variables to body */
-body {
-	background-color: var(--bg-color) !important;
-	color: var(--text-color) !important;
-	transition: background-color 0.3s ease, color 0.3s ease;
+.gvs-body {
+	margin: 0;
+	font-family: var(--pf-t--global--font--family--body, 'Red Hat Text', helvetica, arial, sans-serif);
+	display: flex;
+	flex-direction: column;
 }
 
-/* Theme toggle button */
-.theme-toggle {
-	position: fixed;
-	top: 15px;
-	right: 15px;
-	z-index: 1000;
-	border: none;
-	border-radius: 50%;
-	width: 32px;
-	height: 32px;
-	background: var(--card-bg);
-	color: var(--text-color);
-	border: 1px solid var(--border-color);
-	cursor: pointer;
-	transition: all 0.2s ease;
-	box-shadow: 0 1px 3px var(--shadow-color);
+/* === Top bar === */
+.gvs-topbar {
 	display: flex;
 	align-items: center;
+	justify-content: flex-start;
+	padding: 20px 32px 12px;
+}
+
+.gvs-topbar-brand {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.gvs-brand-text {
+	font-weight: 700;
+	font-size: 1.25em;
+}
+
+/* === Horizontal navigation === */
+.gvs-nav {
+	display: flex;
+	gap: 8px;
+	margin-left: 64px;
+}
+
+.gvs-nav-link {
+	padding: 8px 18px;
+	font-size: 1em;
+	font-weight: 400;
+	color: #151515;
+	text-decoration: none;
+	border-radius: 20px;
+	transition: all 0.2s;
+}
+
+.gvs-nav-link:hover {
+	color: var(--pf-t--global--text--color--regular, #151515);
+	background: rgba(0, 0, 0, 0.05);
+}
+
+.gvs-nav-active {
+	color: #151515 !important;
+	background: #fff !important;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+/* === Views fill viewport below topbar === */
+.gvs-view {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+/* === Main card (wide, rounded, near edges) === */
+.gvs-main-card {
+	background: #fff;
+	border-radius: 24px;
+	box-shadow: none;
+	margin: 8px 24px 24px;
+	overflow-y: auto;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+}
+
+.gvs-gopher-bg {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' opacity='0.15' viewBox='-10 0 420 320'%3E%3Cpath fill='%23FEF0F0' stroke='%23000' stroke-width='3' stroke-linecap='round' d='M46.997,112.853C-13.3,95.897,31.536,19.189,79.956,50.74L46.997,112.853z'/%3E%3Cpath fill='%23FEF0F0' stroke='%23000' stroke-width='3' stroke-linecap='round' d='M314.895,44.984c47.727-33.523,90.856,42.111,35.388,61.141L314.895,44.984z'/%3E%3Cpath d='M49.513,91.667c-7.955-4.208-13.791-9.923-8.925-19.124c4.505-8.518,12.874-7.593,20.83-3.385L49.513,91.667z'/%3E%3Cpath d='M337.716,83.667c7.955-4.208,13.791-9.923,8.925-19.124c-4.505-8.518-12.874-7.593-20.83-3.385L337.716,83.667z'/%3E%3Cpath fill='%23F6D2A2' stroke='%23000' stroke-width='3' stroke-linecap='round' d='M42.53,300c-3,0-7-3-7-8c0-9.22,36.3-39.45,84.94-39.45c-12,30-40,47.45-77.94,47.45z'/%3E%3Cpath fill='%23F6D2A2' stroke='%23000' stroke-width='3' stroke-linecap='round' d='M360,300c3,0,7-3,7-8c0-9.22-36.3-39.45-84.94-39.45c12,30,40,47.45,77.94,47.45z'/%3E%3Cpath fill='%23FEF0F0' stroke='%23000' stroke-width='3' stroke-linecap='round' d='M195.512,13.124c60.365,0,116.953,8.633,146.452,66.629c26.478,65.006,17.062,135.104,21.1,203.806H39.785c-2.24-55.524-17.815-131.742,3.792-196.101C69.999,33.359,130.451,18.271,195.512,13.124'/%3E%3Cpath fill='%23fff' stroke='%23000' stroke-width='2.9' stroke-linecap='round' d='M206.169,94.16c10.838,63.003,113.822,46.345,99.03-17.197C291.935,19.983,202.567,35.755,206.169,94.16'/%3E%3Cpath fill='%23fff' stroke='%23000' stroke-width='2.8' stroke-linecap='round' d='M83.103,104.35c14.047,54.85,101.864,40.807,98.554-14.213C177.691,24.242,69.673,36.957,83.103,104.35'/%3E%3Cpath fill='%23fff' stroke='%23000' stroke-width='3' stroke-linecap='round' d='M218.594,169.762c0.046,8.191,1.861,17.387,0.312,26.101c-2.091,3.952-6.193,4.37-9.729,5.967c-4.89-0.767-9.002-3.978-10.963-8.552c-1.255-9.946,0.468-19.576,0.785-29.526L218.594,169.762z'/%3E%3Cellipse cx='107.324' cy='95.404' rx='14.829' ry='16.062'/%3E%3Cellipse fill='%23fff' cx='114.069' cy='99.029' rx='3.496' ry='4.082'/%3E%3Cellipse cx='231.571' cy='91.404' rx='14.582' ry='16.062'/%3E%3Cellipse fill='%23fff' cx='238.204' cy='95.029' rx='3.438' ry='4.082'/%3E%3Cpath fill='%23fff' stroke='%23000' stroke-width='3' stroke-linecap='round' d='M176.217,168.87c-6.47,15.68,3.608,47.035,21.163,23.908c-1.255-9.946,0.468-19.576,0.785-29.526L176.217,168.87z'/%3E%3Cpath fill='%23F6D2A2' stroke='%23231F20' stroke-width='3' stroke-linecap='round' d='M178.431,138.673c-12.059,1.028-21.916,15.366-15.646,26.709c8.303,15.024,26.836-1.329,38.379,0.203c13.285,0.272,24.17,14.047,34.84,2.49c11.867-12.854-5.109-25.373-18.377-30.97L178.431,138.673z'/%3E%3Cpath d='M176.913,138.045c-0.893-20.891,38.938-23.503,43.642-6.016C225.247,149.475,178.874,153.527,176.913,138.045z'/%3E%3C/svg%3E");
+	background-repeat: no-repeat;
+	background-size: 300px;
+	background-position: bottom -80px right;
+}
+
+.gvs-card-header {
+	padding: 32px 40px 0;
+	text-align: center;
+}
+
+.gvs-card-title {
+	font-size: 1.5em;
+	font-weight: 700;
+	margin: 0;
+	color: var(--pf-t--global--text--color--regular, #151515);
+}
+
+.gvs-card-desc {
+	margin: 4px 0 0;
+	color: var(--pf-t--global--color--nonstatus--gray--default, #6a6e73);
+	font-size: 0.95em;
+}
+
+.gvs-card-body {
+	padding: 32px 40px 40px;
+	flex: 1;
+}
+
+.gvs-two-col {
+	display: flex;
+	gap: 48px;
 	justify-content: center;
-	font-size: 0;
+	align-items: center;
 }
 
-/* Theme toggle icons using CSS */
-.theme-icon {
-	width: 12px;
-	height: 12px;
-	display: block;
-	transition: all 0.2s ease;
+.gvs-col {
+	flex: 1;
+	max-width: 480px;
 }
 
-/* Light mode icon - filled circle */
-.theme-icon.sun {
-	background: var(--text-color);
-	border-radius: 50%;
-	position: relative;
+.gvs-col-ref {
+	border-left: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
+	padding-left: 48px;
 }
 
-/* Dark mode icon - empty circle */
-.theme-icon.moon {
-	background: transparent;
-	border: 2px solid var(--text-color);
-	border-radius: 50%;
-	position: relative;
+/* === Section titles inside card === */
+.gvs-section-title {
+	font-size: 2em;
+	font-weight: 500;
+	text-transform: none;
+	letter-spacing: normal;
+	color: #151515;
+	margin-bottom: 16px;
+	padding-bottom: 8px;
+	border-bottom: none;
 }
 
-.theme-toggle:hover {
-	transform: scale(1.05);
-	box-shadow: 0 2px 8px var(--shadow-color);
+/* === Form label help icon === */
+.pf-v6-c-form__label-help {
+	display: inline-flex;
+	align-items: center;
+	margin-left: 4px;
+	cursor: help;
+	color: var(--pf-t--global--icon--color--regular, #6a6e73);
+	vertical-align: middle;
 }
 
-/* Card styling */
-.card {
-	background-color: var(--card-bg) !important;
-	border-color: var(--border-color) !important;
-	color: var(--text-color) !important;
-	box-shadow: 0 0.125rem 0.25rem var(--shadow-color) !important;
+/* === Advanced options toggle === */
+.gvs-advanced {
+	margin-top: 4px;
 }
 
-/* Form controls */
-.form-control, .form-select {
-	background-color: var(--form-control-bg) !important;
-	border-color: var(--form-control-border) !important;
-	color: var(--text-color) !important;
-}
-
-/* Placeholder styling */
-.form-control::placeholder {
-	color: var(--muted-color) !important;
-	opacity: 1;
-}
-
-/* Disabled form controls */
-.form-control:disabled, .form-select:disabled {
-	background-color: var(--muted-color) !important;
-	color: var(--bg-color) !important;
-	opacity: 0.5 !important;
-	cursor: not-allowed !important;
-}
-
-/* Dark mode disabled form controls */
-[data-theme="dark"] .form-control:disabled, 
-[data-theme="dark"] .form-select:disabled {
-	background-color: #495057 !important;
-	color: #6c757d !important;
-	border-color: #495057 !important;
-}
-
-.form-select {
-	background-image: var(--select-arrow) !important;
-}
-
-.form-control:focus, .form-select:focus {
-	background-color: var(--form-control-bg) !important;
-	border-color: var(--btn-primary-border) !important;
-	color: var(--text-color) !important;
-	box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25) !important;
-}
-
-/* Text color utilities */
-.text-muted {
-	color: var(--muted-color) !important;
-}
-
-/* Code blocks */
-code {
-	font-family: monospace;
-	background-color: var(--code-bg) !important;
-	color: var(--code-color) !important;
-	padding: 0.2rem 0.4rem;
-	border-radius: 0.25rem;
-}
-
-/* Code blocks inside cards should match card background */
-.card code {
-	background-color: var(--card-bg) !important;
-	color: var(--text-color) !important;
-}
-
-.result-card {
-	display: none;
-	padding: 15px;
-	border-radius: 8px;
-	font-family: monospace;
-	border-left: 5px solid var(--result-card-border);
-	margin-top: 20px;
-	overflow: auto;
-	background-color: var(--card-bg);
-	color: var(--text-color);
-}
-
-/* Expandable Card */
-.expandable-card {
+.gvs-advanced summary {
 	cursor: pointer;
-	transition: all 0.3s ease;
-	position: relative;
-	overflow: hidden;
-}
-
-.expandable-card::before {
-	content: '';
-	position: absolute;
-	top: 0;
-	left: -100%;
-	width: 100%;
-	height: 100%;
-	background: linear-gradient(90deg, transparent, rgba(0,0,0,0.03), transparent);
-	transition: left 0.6s ease;
-	pointer-events: none;
-	z-index: 1;
-}
-
-/* Dark mode flash effect */
-[data-theme="dark"] .expandable-card::before {
-	background: linear-gradient(90deg, transparent, rgba(255,255,255,0.03), transparent);
-}
-
-.expandable-card:hover::before {
-	left: 100%;
-}
-
-.expandable-card:hover {
-	transform: translateY(-2px);
-	box-shadow: 0 8px 25px var(--shadow-color);
-}
-
-.card-header-section {
-	position: relative;
-	z-index: 2;
-}
-
-
-.progress-section {
-	margin-top: 0;
-}
-
-
-.progress-content {
-	padding: 0;
-	font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
 	font-size: 0.85em;
-	line-height: 1.4;
-	max-height: 0;
+	font-weight: 600;
+	color: var(--pf-t--global--color--nonstatus--gray--default, #6a6e73);
+	padding: 6px 0;
+	user-select: none;
+}
+
+.gvs-advanced summary:hover {
+	color: var(--gvs-brand);
+}
+
+.gvs-advanced-fields {
+	margin-top: 12px;
+}
+
+/* === Output Reference === */
+.gvs-ref-list {
+	margin: 0;
+}
+
+.gvs-ref-item {
+	padding: 10px 0;
+	font-size: 0.88em;
+	line-height: 1.5;
+}
+
+.gvs-ref-item dt {
+	font-weight: 600;
+	color: var(--pf-t--global--text--color--regular, #151515);
+	margin-bottom: 2px;
+}
+
+.gvs-ref-item dd {
+	margin: 0;
+	color: #151515;
+	font-weight: 400;
+}
+
+/* === Result view split panes === */
+.gvs-result-card {
 	overflow: hidden;
+}
+
+.gvs-result-split {
+	display: flex;
+	flex: 1;
+	min-height: 0;
+}
+
+.gvs-result-pane {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	padding: 24px;
+}
+
+.gvs-log-pane {
+	border-right: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
+}
+
+.gvs-pane-title {
+	font-size: 1.05em;
+	font-weight: 400;
+	text-transform: none;
+	letter-spacing: normal;
+	color: #151515;
+	margin: 0 -24px 12px;
+	padding: 0 24px 10px;
+	border-bottom: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
+	flex-shrink: 0;
+}
+
+/* === Report buttons === */
+#reportContainer .pf-v6-c-button {
+	border-radius: 20px;
+	padding: 2px 12px;
+	font-size: 0.8em;
+	line-height: 1.4;
+}
+
+.gvs-log-output,
+.gvs-scan-output {
+	flex: 1;
+	overflow-y: auto;
+	font-family: var(--pf-t--global--font--family--mono, 'SF Mono', Monaco, monospace);
+	font-size: 1.05em;
+	line-height: 1.5;
 	white-space: pre-wrap;
 	word-wrap: break-word;
-	transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-	background-color: var(--code-bg);
-	border: 1px solid var(--border-color);
+	background: #fff;
 	border-radius: 8px;
-	margin-top: 1rem;
-}
-
-.progress-content:not(.collapsed) {
-	max-height: 350px;
 	padding: 16px;
-	overflow-y: auto;
 }
 
-.progress-content.collapsed {
-	max-height: 0;
-	padding: 0;
-	border: none;
-	margin-top: 0;
-}
-
-.progress-placeholder {
-	color: var(--muted-color);
-	font-style: italic;
-	text-align: center;
-	padding: 24px 0;
-	font-family: inherit;
-}
-
-/* Smooth scrollbar for progress content */
-.progress-content::-webkit-scrollbar {
-	width: 6px;
-}
-
-.progress-content::-webkit-scrollbar-track {
-	background: var(--border-color);
-	border-radius: 3px;
-}
-
-.progress-content::-webkit-scrollbar-thumb {
-	background: var(--btn-primary-bg);
-	border-radius: 3px;
-}
-
-.progress-content::-webkit-scrollbar-thumb:hover {
-	background: #0b5ed7;
-}
-
-.result-card pre {
+.gvs-scan-output pre {
 	margin: 0;
 	white-space: pre-wrap;
 	word-wrap: break-word;
 	overflow-wrap: break-word;
-	color: var(--text-color);
 }
 
-.alert-success { 
-	background-color: var(--alert-success-bg) !important; 
-	border-left-color: var(--alert-success-border) !important; 
-	color: var(--text-color) !important;
+.gvs-log-placeholder {
+	color: var(--pf-t--global--color--nonstatus--gray--default, #6a6e73);
+	font-style: italic;
+	text-align: center;
+	padding: 40px 0;
 }
 
-.alert-warning { 
-	background-color: var(--alert-warning-bg) !important; 
-	border-left-color: var(--alert-warning-border) !important; 
-	color: var(--alert-warning-color) !important; 
+.gvs-log-output::-webkit-scrollbar,
+.gvs-scan-output::-webkit-scrollbar { width: 6px; }
+.gvs-log-output::-webkit-scrollbar-track,
+.gvs-scan-output::-webkit-scrollbar-track { background: #d2d2d2; border-radius: 3px; }
+.gvs-log-output::-webkit-scrollbar-thumb,
+.gvs-scan-output::-webkit-scrollbar-thumb { background: var(--gvs-brand); border-radius: 3px; }
+
+/* === Alert status === */
+.alert-success {
+	background-color: var(--gvs-alert-success-bg) !important;
+	border-left-color: var(--gvs-alert-success-border) !important;
 }
 
-.alert-danger { 
-	background-color: var(--alert-danger-bg) !important; 
-	border-left-color: var(--alert-danger-border) !important; 
-	color: var(--alert-danger-color) !important; 
+.alert-warning {
+	background-color: var(--gvs-alert-warning-bg) !important;
+	border-left-color: var(--gvs-alert-warning-border) !important;
+	color: var(--gvs-alert-warning-color) !important;
 }
 
-.highlight-key { 
-	color: var(--highlight-key-color) !important; 
-	font-weight: bold; 
+.alert-danger {
+	background-color: var(--gvs-alert-danger-bg) !important;
+	border-left-color: var(--gvs-alert-danger-border) !important;
+	color: var(--gvs-alert-danger-color) !important;
 }
 
-.highlight-value { 
-	color: var(--highlight-value-color) !important; 
-	font-weight: bold; 
+/* === Syntax highlighting === */
+.highlight-key { color: var(--gvs-highlight-key) !important; font-weight: bold; }
+.highlight-value { color: var(--gvs-highlight-value) !important; font-weight: bold; }
+
+/* === Graph link === */
+.graph-link { color: var(--gvs-brand); }
+.graph-link:hover { color: var(--gvs-brand-hover); }
+
+
+/* === Feedback modal === */
+.gvs-modal-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
 }
 
-/* Bootstrap component overrides for dark mode */
-[data-theme="dark"] .btn-primary {
-	background-color: var(--btn-primary-bg) !important;
-	border-color: var(--btn-primary-border) !important;
+.gvs-modal {
+	background: #fff;
+	border-radius: 16px;
+	padding: 32px;
+	max-width: 420px;
+	width: 90%;
+	box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+	text-align: center;
 }
 
-[data-theme="dark"] .btn-primary:hover {
-	background-color: #0b5ed7 !important;
-	border-color: #0a58ca !important;
+.gvs-modal-title {
+	font-size: 1.2em;
+	font-weight: 600;
+	margin: 0 0 8px;
 }
 
-[data-theme="dark"] .btn-primary:focus {
-	background-color: #0b5ed7 !important;
-	border-color: #0a58ca !important;
-	box-shadow: 0 0 0 0.25rem rgba(49, 132, 253, 0.5) !important;
+.gvs-modal-desc {
+	color: #151515;
+	font-size: 0.9em;
+	margin: 0 0 24px;
 }
 
-[data-theme="dark"] .btn-primary:disabled {
-	background-color: #0d6efd !important;
-	border-color: #0d6efd !important;
-	opacity: 0.65;
+.gvs-modal-actions {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
-/* Tooltip styling for light mode */
-.tooltip .tooltip-inner {
-	background-color: white !important;
-	color: black !important;
-	border: 1px solid #dee2e6;
+.gvs-modal-actions .pf-v6-c-button {
+	border-radius: 8px;
 }
 
-.tooltip .tooltip-arrow::before {
-	border-top-color: #dee2e6 !important;
+.report-actions .pf-v6-c-button {
+	border-radius: 20px;
+	padding: 2px 12px;
+	font-size: 0.8em;
+	line-height: 1.4;
 }
 
-/* Tooltip styling for dark mode */
-[data-theme="dark"] .tooltip .tooltip-inner {
-	background-color: var(--card-bg) !important;
-	color: var(--text-color) !important;
-	border: 1px solid var(--border-color);
+
+/* === Footer === */
+.gvs-footer {
+	text-align: center;
+	padding: 24px;
+	font-size: 0.8em;
+	color: var(--pf-t--global--color--nonstatus--gray--default, #6a6e73);
 }
 
-[data-theme="dark"] .tooltip .tooltip-arrow::before {
-	border-top-color: var(--border-color) !important;
+/* === History === */
+.gvs-history-table {
+	width: 100%;
+	border-collapse: collapse;
 }
 
-/* Ensure smooth transitions for all themed elements */
-* {
-	transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+.gvs-history-table th,
+.gvs-history-table td {
+	padding: 10px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
 }
 
-/* Responsive design for theme toggle on mobile */
+.gvs-history-table th {
+	font-weight: 600;
+	font-size: 0.82em;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--pf-t--global--color--nonstatus--gray--default, #6a6e73);
+}
+
+.gvs-history-table tr:last-child td { border-bottom: none; }
+.gvs-history-table tr:hover td { background: rgba(0, 0, 0, 0.02); }
+
+/* === Status labels === */
+.gvs-label {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 3px;
+	font-size: 0.8em;
+	font-weight: 600;
+}
+
+.gvs-label-success { background: var(--gvs-alert-success-bg); color: #155724; }
+.gvs-label-danger { background: var(--gvs-alert-danger-bg); color: var(--gvs-alert-danger-color); }
+.gvs-label-warning { background: var(--gvs-alert-warning-bg); color: var(--gvs-alert-warning-color); }
+
+/* === Responsive === */
+@media (max-width: 900px) {
+	.gvs-two-col {
+		flex-direction: column;
+		gap: 32px;
+	}
+	.gvs-col {
+		max-width: 100%;
+	}
+	.gvs-col-ref {
+		border-left: none;
+		padding-left: 0;
+		border-top: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
+		padding-top: 32px;
+	}
+}
+
+@media (max-width: 900px) {
+	.gvs-result-split {
+		flex-direction: column;
+	}
+	.gvs-log-pane {
+		border-right: none;
+		border-bottom: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
+	}
+	.gvs-result-pane {
+		flex: none;
+		max-height: 50%;
+	}
+}
+
 @media (max-width: 768px) {
-	.theme-toggle {
-		top: 10px;
-		right: 10px;
-		width: 28px;
-		height: 28px;
+	.gvs-main-card {
+		margin: 8px 12px;
+		border-radius: 16px;
 	}
-	
-	.theme-icon {
-		width: 10px;
-		height: 10px;
+	.gvs-card-header {
+		padding: 24px 20px 0;
 	}
-	
-	.theme-icon.moon {
-		border: 1px solid var(--text-color);
+	.gvs-card-body {
+		padding: 16px 20px 24px;
 	}
-}
-
-/* Focus styles for accessibility */
-.theme-toggle:focus {
-	outline: 2px solid var(--btn-primary-bg);
-	outline-offset: 2px;
-}
-
-/* Report Inaccuracy Button */
-.report-container {
-	margin-top: 10px;
-	text-align: right;
-}
-
-.btn-outline-secondary {
-	color: var(--muted-color);
-	border-color: var(--muted-color);
-	background-color: transparent;
-}
-
-.btn-outline-secondary:hover {
-	background-color: var(--muted-color);
-	color: var(--bg-color);
-	border-color: var(--muted-color);
+	.gvs-topbar {
+		padding: 12px 16px;
+		flex-direction: column;
+		gap: 12px;
+	}
+	.gvs-result-area {
+		margin: 16px 12px;
+	}
 }

--- a/site/styles.css
+++ b/site/styles.css
@@ -189,6 +189,11 @@ html, body {
 
 .gvs-advanced-fields {
 	margin-top: 12px;
+	font-size: 1rem;
+}
+
+.gvs-advanced-fields .pf-v6-c-form__group + .pf-v6-c-form__group {
+	margin-top: var(--pf-v6-c-form--m-horizontal--spacer, 1rem);
 }
 
 /* === Output Reference === */
@@ -237,16 +242,45 @@ html, body {
 	border-right: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
 }
 
+.gvs-pane-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin: 0 -24px 12px;
+	padding: 0 24px 10px;
+	border-bottom: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
+	flex-shrink: 0;
+}
+
 .gvs-pane-title {
 	font-size: 1.05em;
 	font-weight: 400;
 	text-transform: none;
 	letter-spacing: normal;
 	color: #151515;
-	margin: 0 -24px 12px;
-	padding: 0 24px 10px;
-	border-bottom: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
-	flex-shrink: 0;
+	margin: 0;
+}
+
+.gvs-copy-btn {
+	background: none;
+	border: 1px solid transparent;
+	border-radius: 4px;
+	color: #6a6e73;
+	cursor: pointer;
+	padding: 4px 6px;
+	line-height: 1;
+	display: inline-flex;
+	align-items: center;
+	transition: color 0.15s, border-color 0.15s;
+}
+
+.gvs-copy-btn:hover {
+	color: var(--gvs-brand);
+	border-color: var(--pf-t--global--border--color--default, #e0e0e0);
+}
+
+.gvs-copy-btn.copied {
+	color: var(--gvs-brand);
 }
 
 /* === Report buttons === */
@@ -310,9 +344,18 @@ html, body {
 	color: var(--gvs-alert-danger-color) !important;
 }
 
-/* === Syntax highlighting === */
+/* === JSON syntax highlighting === */
 .highlight-key { color: var(--gvs-highlight-key) !important; font-weight: bold; }
 .highlight-value { color: var(--gvs-highlight-value) !important; font-weight: bold; }
+
+/* === Log syntax highlighting === */
+.log-claude { color: var(--pf-t--global--color--status--info--default, #0066cc); }
+.log-success { color: var(--pf-t--global--color--status--success--default, #3e8635); }
+.log-error { color: var(--pf-t--global--color--status--danger--default, #c9190b); }
+.log-warn { color: var(--pf-t--global--color--status--warning--default, #f0ab00); }
+.log-info { color: var(--pf-t--global--text--color--subtle, #6a6e73); }
+.log-status { font-weight: 600; }
+.log-tool { font-weight: 600; color: var(--pf-t--global--color--nonstatus--purple--default, #6753ac); }
 
 /* === Graph link === */
 .graph-link { color: var(--gvs-brand); }


### PR DESCRIPTION
Replace Bootstrap 5 with PatternFly 6 as the frontend CSS framework,
adopting Red Hat's design system for a consistent enterprise look.

Key changes:
- Replace Bootstrap grid/form/card classes with PatternFly v6 equivalents
  (pf-v6-c-form, pf-v6-l-grid, pf-v6-c-button)
- Redesign layout with branded top bar, tab navigation (New Scan,
  Result, Scan History), and split-pane result view
- Add Red Hat fedora logo and GVS branding with custom theme variables
- Replace Bootstrap dark mode toggle with PatternFly's light theme
- Add scan history view with localStorage persistence and View/Clear
  actions
- Add form input history with datalist autocomplete for previously
  used values
- Rewrite all custom CSS to use PatternFly design tokens and
  CSS custom properties
- Add FAQ/reference section with output field descriptions
- Add feedback modal for reporting scan inaccuracies

Cache cg stderr logs alongside scan results so progress logs (including
Claude verification details) persist across cache hits. Logs are returned
in the /status response to avoid SSE race conditions on fast cache
lookups.

Add syntax highlighting for progress logs using PatternFly v6 design
tokens - Claude interactions in blue, success in green, errors in red,
warnings in yellow, and tool names in purple.

UI improvements:
- Add copy-to-clipboard button for Progress Log and Scan Result panes
  with fallback for non-HTTPS contexts
- Add Algorithm and AI Agrees columns to Scan History table
- Save progress logs to scan history for replay on View
- Align advanced fields (Library/Symbol/Fixed Version) spacing with
  main form fields
- Update truth table: Vulnerable+Disagrees verdict changed to
  Not Vulnerable

Signed-off-by: Vinu K <kevy.vinu@gmail.com>