### PR TITLE
SUSTAINING-2835: Mitigate anchoring bias in Claude verification prompt

### DIFF
--- a/pkg/cmd/cg/verify.go
+++ b/pkg/cmd/cg/verify.go
@@ -895,7 +895,6 @@ func loadSkillPrompt() (string, bool) {
 
 func buildVerificationPrompt(result *Result, skillTemplate string, sourceSnippets map[string]string) (string, error) {
 	promptResult := struct {
-		IsVulnerable    string                            `json:"IsVulnerable"`
 		UsedImports     map[string]UsedImportsDetails     `json:"UsedImports,omitempty"`
 		AffectedImports map[string]AffectedImportsDetails `json:"AffectedImports,omitempty"`
 		GoCVE           string                            `json:"GoCVE"`
@@ -905,7 +904,6 @@ func buildVerificationPrompt(result *Result, skillTemplate string, sourceSnippet
 		ReflectionRisks []ReflectionRisk                  `json:"ReflectionRisks,omitempty"`
 		Errors          []string                          `json:"Errors,omitempty"`
 	}{
-		IsVulnerable:    result.IsVulnerable,
 		UsedImports:     result.UsedImports,
 		AffectedImports: result.AffectedImports,
 		GoCVE:           result.GoCVE,

--- a/skills/verify-scan.md
+++ b/skills/verify-scan.md
@@ -1,12 +1,12 @@
 # GVS Vulnerability Scan Verification
 
-You are an independent security auditor reviewing the output of GVS (Go Vulnerability Scanner). Your role is to verify whether the scanner's conclusion is correct by analyzing the scan data and source code provided.
+You are an independent security auditor reviewing the output of GVS (Go Vulnerability Scanner). Your role is to independently determine whether this repository is vulnerable to a specific CVE, then compare your conclusion against the scanner's.
 
-**Critical rule: You are an auditor. You do NOT modify the scanner's `IsVulnerable` field. You provide your independent assessment, reasoning, and evidence.**
+**Critical rule: You are an auditor. You form your OWN conclusion first, then compare it with the scanner's. Your independent assessment takes priority over the scanner's when they conflict.**
 
 ## Scanner Data
 
-The scanner analyzed a Go repository for a specific CVE. Here is the scan result:
+The scanner analyzed a Go repository for a specific CVE. Here is the scan data (note: the scanner's vulnerability verdict is withheld until Step 4 to avoid anchoring your analysis):
 
 ```json
 {{.scan_result_json}}
@@ -41,39 +41,37 @@ You have access to tools for interactively exploring the repository and querying
 - **read_file**: Read a specific file (or a line range within it). Use to inspect code around call sites, verify dead-code conditions, or check build constraints.
 - **list_files**: List files in a directory. Use to understand project structure or find test files vs production files.
 - **find_implementations**: Given an interface type name (e.g., `"io.Writer"`), returns all concrete types in the program that implement it and whether each is instantiated (used as an interface value). Use to verify interface dispatch edges in call traces. One call replaces many grep searches for type instantiations.
-- **find_callers**: Given a function/method name, performs reverse BFS on the call graph to find all callers up to N hops backward. Returns caller chains with edge types and highlights entry points. Use when the scanner says "false" but you suspect a missed path -- the reverse traversal may reveal callers the forward BFS missed due to unrecognized entry points.
+- **find_callers**: Given a function/method name, performs reverse BFS on the call graph to find all callers up to N hops backward. Returns caller chains with edge types and highlights entry points. Use when you suspect a missed path -- the reverse traversal may reveal callers the forward BFS missed due to unrecognized entry points.
 
 **You have a limited number of tool calls. Prioritize `find_implementations` and `find_callers` over manual `grep_code` searches when investigating interface dispatch or call reachability.**
 
-**Investigation priority for false positives (scanner says "true"):**
+**Investigation checklist: could the code be vulnerable?**
+1. Call `find_callers` for the vulnerable symbol to check if a path exists from entry points
+2. If `find_callers` shows callers chaining back to an entry point, there IS a vulnerability path
+3. If `find_callers` shows callers reaching framework-pattern functions (gin, gRPC, echo, fiber, chi), there may be an unrecognized entry point
+4. Call `find_implementations` for the vulnerable interface (if applicable) to check if a concrete type IS instantiated
+5. Use `grep_code` for reflection, string-literal symbol references, or plugin/driver registration patterns
+
+**Investigation checklist: could a vulnerability path be unreachable?**
 1. Check call traces for edges marked `"dynamic method call via interface X.Y"`
 2. Call `find_implementations` for interface X
-3. If the callee's receiver type shows `"instantiated: NO"`, it is a false positive
+3. If the callee's receiver type shows `"instantiated: NO"`, the path is phantom (over-approximation)
 4. If instantiated, use `find_callers` to verify the caller chain is real
 5. Fall back to `grep_code` / `read_file` only if the above tools are unavailable
-
-**Investigation priority for false negatives (scanner says "false"):**
-1. Call `find_callers` for the vulnerable symbol to check if a reverse path exists
-2. If `find_callers` shows callers chaining back to an entry point, the scanner missed a path -- flag as false negative
-3. If `find_callers` shows callers reaching framework-pattern functions (gin, gRPC, echo, fiber, chi), the scanner missed an entry point
-4. Call `find_implementations` for the vulnerable interface (if applicable) to check if a concrete type IS instantiated but the scanner missed the type flow
-5. Use `grep_code` for reflection, string-literal symbol references, or plugin/driver registration patterns
 
 **Important: You MUST respond with the final JSON after you finish using tools. Do not end with a tool call.**
 
 ## Verification Instructions
 
-### Step 1: Understand the scanner's conclusion
+### Step 1: Form your initial hypothesis
 
-The scanner concluded: `IsVulnerable = {{.is_vulnerable}}`
+Review `UsedImports`, `AffectedImports`, `ReflectionRisks`, call graph traces, and `Errors` to understand what the scanner found. **Do NOT skip ahead to the scanner's conclusion in Step 4.** Form your own preliminary view of whether the code is vulnerable.
 
-Review the `UsedImports`, `AffectedImports`, `ReflectionRisks`, and `Errors` fields to understand how the scanner reached this conclusion.
+### Step 2: Check for missed vulnerability paths
 
-### Step 2: Check for false negatives (scanner says "false" but may be wrong)
+Regardless of what the call traces show, actively look for these scenarios:
 
-If the scanner says the repository is NOT vulnerable, check for these scenarios:
-
-1. **Reflection-based usage**: Look at `ReflectionRisks` and the source code for `reflect.MethodByName`, `reflect.ValueOf`, function registries (maps of string to func), or string literals matching vulnerable symbol names. The scanner detects these but does NOT factor them into `IsVulnerable`.
+1. **Reflection-based usage**: Look at `ReflectionRisks` and the source code for `reflect.MethodByName`, `reflect.ValueOf`, function registries (maps of string to func), or string literals matching vulnerable symbol names. The scanner detects these but does NOT factor them into its verdict.
 
 2. **Call graph imprecision**: The algorithm `{{.algorithm}}` has known limitations:
    - `static`: Only detects direct function calls. Misses all interface/dynamic dispatch.
@@ -94,25 +92,25 @@ If the scanner says the repository is NOT vulnerable, check for these scenarios:
    - Type aliases or embedded types that expose the vulnerable method
    - Generic instantiations that use the vulnerable type
 
-6. **Missed type flow (VTA/RTA)**: When `find_implementations` shows a concrete type that implements the vulnerable interface AND is instantiated, but the scanner found no path, investigate whether the type flows to the call site through:
+6. **Missed type flow (VTA/RTA)**: When `find_implementations` shows a concrete type that implements the vulnerable interface AND is instantiated, but no call trace reaches it, investigate whether the type flows to the call site through:
    - Channel send/receive (type crosses goroutine boundaries)
    - Global variable assignment (type stored globally, read elsewhere)
    - Generic instantiation (type parameter resolved to the concrete type)
    - Complex closures (type captured in a closure that is later invoked)
    Use `find_callers` on intermediate functions to trace the actual path.
 
-7. **Scanner result is "unknown"**: If the scanner concluded `"unknown"`, investigate aggressively. Use `find_callers` to check if the vulnerable symbol has any callers. Use `find_implementations` to check if relevant interface types have instantiated implementors. The scanner could not determine status due to package load failures, missing entry points, or toolchain version ambiguity.
+7. **Unknown status**: If you cannot determine vulnerability status due to insufficient data, use `find_callers` to check if the vulnerable symbol has any callers. Use `find_implementations` to check if relevant interface types have instantiated implementors.
 
-### Step 3: Check for false positives (scanner says "true" but may be wrong)
+### Step 3: Check for unreachable or phantom paths
 
-If the scanner says the repository IS vulnerable, check for these scenarios:
+If call traces exist, actively check whether they represent real vulnerability:
 
 1. **Dead code paths**: The call graph shows a path to the vulnerable symbol, but examine the source code for:
    - Always-false conditions guarding the call (`if false {`, `if runtime.GOOS == "windows"` on a Linux-only project)
    - Unreachable branches after early returns or panics
    - Compile-time constant guards that eliminate the path
 
-2. **Call graph over-approximation**: Especially with `cha` algorithm, which includes ALL methods matching an interface signature even when the concrete type is never instantiated. Check the **Call Graph Traces** above for edges marked `"dynamic method call via interface X.Y"` -- these are the most likely false positives. Use `find_implementations` for the interface to check if the callee's concrete type is actually instantiated. If `"instantiated: NO"`, it is a false positive.
+2. **Call graph over-approximation**: Especially with `cha` algorithm, which includes ALL methods matching an interface signature even when the concrete type is never instantiated. Check call traces for edges marked `"dynamic method call via interface X.Y"` -- these are the most likely phantom paths. Use `find_implementations` for the interface to check if the callee's concrete type is actually instantiated. If `"instantiated: NO"`, the path is not real.
 
    **Harder cases:**
    - Factory patterns: Even if `find_implementations` shows a type is instantiated, check if the factory function that creates it is actually called. Use `find_callers` on the factory function.
@@ -127,12 +125,17 @@ If the scanner says the repository IS vulnerable, check for these scenarios:
 
 6. **Test-only reachability**: If the call path to the vulnerable symbol only exists in test files that were inadvertently included in the analysis, the production code is not actually vulnerable.
 
-### Step 4: Form your assessment
+### Step 4: Compare with the scanner and form your final assessment
 
-Based on your analysis:
-- Do you agree with the scanner's `IsVulnerable` conclusion?
-- If you disagree, what specific evidence supports your assessment?
-- How confident are you? Use `high` only when you have concrete code evidence (file paths, line numbers, specific patterns). Use `medium` when the evidence is suggestive but not definitive. Use `low` when it's a theoretical concern.
+**First**, commit to your own independent assessment based on Steps 1-3. Decide: is this repository vulnerable (`"true"`), not vulnerable (`"false"`), or indeterminate (`"unknown"`)?
+
+**Now** compare with the scanner's conclusion:
+
+> The scanner concluded: `IsVulnerable = {{.is_vulnerable}}`
+
+- If you agree, cite the strongest supporting evidence.
+- If you disagree, your independent assessment takes priority. Explain what the scanner got wrong and cite the specific evidence.
+- Use `high` confidence only when you have concrete code evidence (file paths, line numbers, specific patterns). Use `medium` when the evidence is suggestive but not definitive. Use `low` when it's a theoretical concern.
 
 ## Required Response Format
 
@@ -141,7 +144,7 @@ After completing your investigation (including any tool usage), respond with ONL
 Rules:
 - `reasoning`: 1-3 sentences. State your verdict and the key reason. Reference specific file:line if disagreeing.
 - `evidence`: Each entry must be `file:line: <what was found>` or a tool result summary. Always include at least one evidence entry, even if you agree with the scanner (cite the strongest supporting evidence such as call trace step, find_callers result, or instantiation status).
-- `claude_assessment`: Must be exactly `"true"`, `"false"`, or `"unknown"`.
+- `claude_assessment`: Must be exactly `"true"`, `"false"`, or `"unknown"`. This is YOUR assessment, not the scanner's.
 - Do NOT repeat the scanner result or restate the CVE description.
 
 {


### PR DESCRIPTION
The Claude verification step was agreeing with contradictory scanner results for the same repo/branch/CVE across different algorithms (VTA vs RTA). The root cause was anchoring bias: Claude saw the scanner's IsVulnerable verdict upfront and rationalized it rather than forming an independent assessment.

Changes:
- Restructure verify-scan.md to blind-then-compare flow: Claude now investigates and commits to its own verdict (Steps 1-3) before the scanner's conclusion is revealed in Step 4
- Remove IsVulnerable from the JSON blob sent to Claude in buildVerificationPrompt so the verdict is not leaked in the data
- Reframe investigation checklists as neutral ("check for missed paths" / "check for unreachable paths") instead of presupposing the scanner's answer ("false positives" / "false negatives")
- Strengthen auditor instruction: Claude's independent assessment takes priority when it conflicts with the scanner